### PR TITLE
Fix control-port bug in SLURM?

### DIFF
--- a/clusterutils/build_mpirun_configfile.py
+++ b/clusterutils/build_mpirun_configfile.py
@@ -223,7 +223,11 @@ class SLURMHydraConfigCreator(HydraConfigFileCreator):
 
     def extract_host_cuda_visible_devs(self):
         host_list = self.extract_hostlist()
-        host_set = set(host_list)
+        # Ensure we get an ordered "set", normal set is un-ordered
+        # We don't care that its a dict, we only need the keys
+        # This fixes a rare bug appearing to involve SLURM and Hydra MPI's --control-port when the first node
+        # in the config file is not the control-port
+        host_set = collections.OrderedDict.fromkeys(sorted(host_list))
         cvd_list = []
         for host in host_set:
             cvds = self.cuda_visible_devices[host]
@@ -260,8 +264,8 @@ def figure_out_manager(mpiversion):
         return SLURMHydraConfigCreator(mpiversion)
     raise RuntimeError("Cannot determine job scheduler!\n"
                        "Please ensure one of the following environment variables is set for your job:\n"
-                       "    PBS: \"PBS_GPUFILE\""
-                       "    LSF: \"LSB_HOSTS\""
+                       "    PBS: \"PBS_GPUFILE\"\n"
+                       "    LSF: \"LSB_HOSTS\"\n"
                        "  SLURM: \"SLURM_JOB_NODELIST\"")
 
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: !!str dev
 
 source:
-   git_url: https://github.com/choderalab/clusterutils
+   path: ../..
 
 build:
   entry_points:
@@ -12,7 +12,6 @@ build:
 requirements:
   build:
     - python
-    - distribute
 
   run:
     - python

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import subprocess
 from setuptools import setup
 
 ##########################
-VERSION = "0.3.0"
+VERSION = "0.3.1"
 ISRELEASED = True
 __version__ = VERSION
 ##########################


### PR DESCRIPTION
SLURM runs can fail when the --control-port is not the first node in nodelist. This ensures the first
host is always the first host on the list to get around it. I can't 100% confirm this is the cause, but this does at least fix it.

Other changes:
* Internal meta.yaml file fixed to point at local build instead of git (for local testing)
* Bumped version to 0.3.1